### PR TITLE
Indicate missing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - New `uair` config key: `iterations`. Allows to specify a finite amount of iterations of all sessions.
 
+#### Changed
+
+- Improve error message by indicating a missing config file. (@thled)
+
 #### Removed
 
 - `-p` and `-r` `uairctl` flags. Use `pause`, `resume` and `toggle` subcommands instead.

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+with import <nixpkgs> { };
+stdenv.mkDerivation {
+  name = "uair";
+  buildInputs = [
+    cargo
+    cargo-watch
+    clippy
+    rustc
+    rustfmt
+  ];
+}


### PR DESCRIPTION
When I first started the tool I was surprised by the message `IO Error: No such file or directory (os error 2)`. I didn't expect a timer tool to read a file.

I thought a hint that it needs a configuration file would be good. Thats what this PR is for.

Maybe a next step is a default config just to get started without errors if you want to try out the tool.