### PR TITLE
Added time_format option and implemented it.

### DIFF
--- a/docs/uair.5.scd
+++ b/docs/uair.5.scd
@@ -46,6 +46,9 @@ The number of pomodoro sessions and their properties can be specified by an uair
 *format*
 	Specifies the format in which text is printed each second. See FORMAT SPECIFIERS section for details.
 
+*time_format*
+	Specifies the time format for *{time}*. Possible values: *Humantime* or *MinSec*.
+
 *autostart*
 	Boolean value (true or false) which dictates whether the session automatically starts.
 

--- a/src/bin/uair/config.rs
+++ b/src/bin/uair/config.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 use std::str::FromStr;
 use serde::{Serialize, Deserialize};
 use crate::session::{Color, Session, Token};
+use crate::time_format::TimeFormat;
 
 pub struct Config {
 	pub iterations: Option<u64>,
@@ -46,6 +47,9 @@ impl ConfigBuilder {
 				duration: s.duration.unwrap_or_else(|| self.defaults.duration.clone()),
 				command: s.command.unwrap_or_else(|| self.defaults.command.clone()),
 				format: Self::fetch_format(s.format, s.before, s.after, &self.defaults),
+				time_format: Self::parse_time_format(
+                    &s.time_format.unwrap_or_else(|| self.defaults.time_format.clone())
+                ),
 				autostart: s.autostart.unwrap_or_else(|| self.defaults.autostart.clone()),
 				paused_state_text: s.paused_state_text.unwrap_or_else(|| self.defaults.paused_state_text.clone()),
 				resumed_state_text: s.resumed_state_text.unwrap_or_else(|| self.defaults.resumed_state_text.clone()),
@@ -68,6 +72,15 @@ impl ConfigBuilder {
 		}
 	}
 
+	fn parse_time_format(unparsed: &str) -> TimeFormat {
+		let unparsed = unparsed.to_lowercase();
+
+		match &unparsed[..] {
+			"humantime" => TimeFormat::Humantime,
+			"minsec" => TimeFormat::MinSec,
+			_ => TimeFormat::Humantime,
+		}
+	}
 	fn from_before_after(before: String, after: String) -> Vec<Token> {
 		vec![Token::Literal(before), Token::Time, Token::Literal(after)]
 	}
@@ -88,6 +101,8 @@ pub struct Defaults {
 	after: String,
 	#[serde(default = "Defaults::format")]
 	format: Option<String>,
+	#[serde(default = "Defaults::time_format")]
+	time_format: String,
 	#[serde(default = "Defaults::autostart")]
 	autostart: bool,
 	#[serde(default = "Defaults::paused_state_text")]
@@ -103,6 +118,7 @@ impl Defaults {
 	fn before() -> String { "".into() }
 	fn after() -> String { "\n".into() }
 	fn format() -> Option<String> { None }
+	fn time_format() -> String { "Humantime".into() }
 	fn autostart() -> bool { false }
 	fn paused_state_text() -> String { "⏸".into() }
 	fn resumed_state_text() -> String { "⏵".into() }
@@ -117,6 +133,7 @@ impl Default for Defaults {
 			before: Defaults::before(),
 			after: Defaults::after(),
 			format: Defaults::format(),
+			time_format: Defaults::time_format(),
 			autostart: Defaults::autostart(),
 			paused_state_text: Defaults::paused_state_text(),
 			resumed_state_text: Defaults::resumed_state_text(),
@@ -134,6 +151,7 @@ struct SessionBuilder {
 	before: Option<String>,
 	after: Option<String>,
 	format: Option<String>,
+	time_format: Option<String>,
 	autostart: Option<bool>,
 	paused_state_text: Option<String>,
 	resumed_state_text: Option<String>,

--- a/src/bin/uair/main.rs
+++ b/src/bin/uair/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod socket;
 mod session;
 mod timer;
+mod time_format;
 
 use std::env;
 use std::io;

--- a/src/bin/uair/session.rs
+++ b/src/bin/uair/session.rs
@@ -3,12 +3,14 @@ use std::io;
 use std::process;
 use std::time::Duration;
 use humantime::format_duration;
+use crate::time_format::TimeFormat;
 
 pub struct Session {
 	pub name: String,
 	pub duration: Duration,
 	pub command: String,
 	pub format: Vec<Token>,
+	pub time_format: TimeFormat,
 	pub autostart: bool,
 	pub paused_state_text: String,
 	pub resumed_state_text: String,
@@ -56,7 +58,9 @@ impl<'session, 'token, const R: bool> Display for DisplayableSession<'session, '
 					self.time.as_secs_f32() * 100.0 / self.session.duration.as_secs_f32()
 				) as u8)?,
 				Token::Time => write!(f, "{}",
-					format_duration(Duration::from_secs(self.time.as_secs())))?,
+					&self.session.time_format.format_duration(
+						Duration::from_secs(self.time.as_secs()))
+					)?,
 				Token::Total => write!(f, "{}", format_duration(self.session.duration))?,
 				Token::State => write!(f, "{}", if R {
 					&self.session.resumed_state_text

--- a/src/bin/uair/time_format.rs
+++ b/src/bin/uair/time_format.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+use humantime::format_duration;
+
+pub enum TimeFormat {
+	Humantime,
+	MinSec,
+}
+
+impl TimeFormat {
+	pub fn format_duration(&self, duration: Duration) -> String {
+		match &self {
+			TimeFormat::Humantime => Self::humantime(duration),
+			TimeFormat::MinSec => Self::min_sec(duration),
+		}
+	}
+
+	fn humantime(duration: Duration) -> String {
+		format!("{}", format_duration(duration))
+	}
+
+	/// Formats duration as `min:sec` or `hour:min:sec` in case more then 1 hour.
+	///
+	/// # Examples
+	/// ```
+	/// let formatted = time_format.min_sec(Duration::from_secs(1234);
+	/// 
+	/// assert_eq!("20:34", formatted);
+	/// ```
+	fn min_sec(duration: Duration) -> String {
+		let secs = duration.as_secs();
+
+		if secs >= 86400 {
+			panic!("Duration should not exceed 24 hours: {}", format_duration(duration));
+		}
+
+		let hours = secs / 3600;
+		let minutes = (secs / 60) % 60;
+		let seconds = secs % 60;
+
+		if secs >= 3600 {
+			return format!("{hours:0>2}:{minutes:0>2}:{seconds:0>2}");
+		}
+
+		format!("{minutes:0>2}:{seconds:0>2}")
+	}
+}
+
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn valid_min_sec() {
+		assert_eq!("00:00", TimeFormat::min_sec(Duration::from_secs(0)));
+		assert_eq!("00:11", TimeFormat::min_sec(Duration::from_secs(11)));
+		assert_eq!("03:23", TimeFormat::min_sec(Duration::from_secs(203)));
+		assert_eq!("59:59", TimeFormat::min_sec(Duration::from_secs(3599)));
+		assert_eq!("01:00:11", TimeFormat::min_sec(Duration::from_secs(3611)));
+		assert_eq!("11:00:00", TimeFormat::min_sec(Duration::from_secs(39600)));
+		assert_eq!("23:59:59", TimeFormat::min_sec(Duration::from_secs(86399)));
+	}
+
+	#[test]
+	#[should_panic]
+	fn min_sec_overflowed() {
+		TimeFormat::min_sec(Duration::from_secs(86400)); // one day
+	}
+}


### PR DESCRIPTION
This is a great customizable pomodoro timer! So I use it daily. But I needed some other time formatting in the Polybar (e.g. 01:23 == 1m 23s) because the humantime formatted view jumps to often for me. As an example when the time switches from "1m 01s" to "1m" it changes the length too obvious for me and that distracts me.
So I implemented an alternative configurable view.
In the configuration you can add time_format = "MinSec" and the view turns into 'min:sec'.
If it is not added, then the default view in humantime is showed like in the past.
Please have a look at the screenshot how it looks in my polybar view now.

If you find it useful, I would be happy if you could add this feature :)

![DeepinScreenshot_select-area_20230202104738](https://user-images.githubusercontent.com/124146488/216290275-946e5ef2-fffb-45b6-a067-5c0fcc1d96fe.png)
