### PR TITLE
Fix cargo lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Check Cargo.lock
+        run: cargo fetch --locked
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "uair"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "argh",
  "async-io",


### PR DESCRIPTION
The new release v0.6.0 is broken because the version wasn't updated in the `Cargo.lock` file.

I also added a step in the pipeline which fails if the `Cargo.lock` and `Cargo.toml` are out of sync (see https://github.com/thled/uair/actions/runs/5451011959/jobs/9916847735 for a failing example).