### PR TITLE
fix(uairctl): strip \0 delimiter and flush listen output

### DIFF
--- a/src/bin/uairctl/main.rs
+++ b/src/bin/uairctl/main.rs
@@ -33,7 +33,11 @@ fn main() -> Result<(), Error> {
 				if buf.is_empty() {
 					break;
 				}
-				write!(io::stdout(), "{}", str::from_utf8(&buf)?)?;
+				if buf.last() == Some(&b'\0') {
+					buf.pop();
+				}
+				writeln!(io::stdout(), "{}", str::from_utf8(&buf)?)?;
+				io::stdout().flush()?;
 				buf.clear();
 			}
 		}


### PR DESCRIPTION


<!-- PR_SUMMARY_START -->
- fix(uairctl): strip \0 delimiter and flush listen output

  read_until(b'\0') includes the delimiter in the buffer, corrupting
  output. Use writeln + flush so each update is a newline-terminated,
  immediately-flushed line for consumers like waybar.

  Fixes #15
<!-- PR_SUMMARY_END -->